### PR TITLE
Add support for a dev database

### DIFF
--- a/deployments/docker-compose-dev.yaml
+++ b/deployments/docker-compose-dev.yaml
@@ -1,0 +1,8 @@
+version: "3.7"
+services:
+  database:
+    image: postgres:14.2
+    environment:
+      POSTGRES_PASSWORD: password1234
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
This PR resolves #1 by adding a docker-compose-dev.yaml file.  When the docker-compose-dev.yaml file is launched, a postgres server is created locally and is available at localhost:5432.