### PR TITLE
Add database libraries and examples

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"database/sql"
+	"log"
+
 	"github.com/gin-gonic/gin"
+	_ "github.com/lib/pq"
 )
 
-func main() {
-	r := gin.Default()
+// configureRoutes sets up the routes for the REST server
+func configureRoutes(r *gin.Engine) {
 	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(200, gin.H{
 			"message": "pong",
@@ -14,5 +18,52 @@ func main() {
 	r.GET("/", func(c *gin.Context) {
 		c.String(200, "Hello World")
 	})
+}
+
+// createDatabase creates a database named dbName
+func createDatabase(dbName string) {
+	db, err := sql.Open("postgres", "postgres://postgres:password1234@localhost:5432/postgres?sslmode=disable")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	// Create the database
+	_, err = db.Exec("CREATE DATABASE " + dbName)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// createTables creates the tables in the database specified by dbName
+func createTables(dbName string) {
+	db, err := sql.Open("postgres", "postgres://postgres:password1234@localhost:5432/"+dbName+"?sslmode=disable")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	// Create the table
+	sqlStatement := `CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL);`
+	_, err = db.Exec(sqlStatement)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// main entrypoint for the program
+func main() {
+	// create necessary resources
+	r := gin.Default()
+	dbName := "testdb"
+
+	// perform configuration for REST server
+	configureRoutes(r)
+
+	// perform configuration for database
+	createDatabase(dbName)
+	createTables(dbName)
+
+	// start the server
 	r.Run()
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/NateJSchmidt/chronicler
 
 go 1.18
 
-require github.com/gin-gonic/gin v1.7.7
+require (
+	github.com/gin-gonic/gin v1.7.7
+	github.com/lib/pq v1.10.5
+)
 
 require (
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGn
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/lib/pq v1.10.5 h1:J+gdV2cUmX7ZqL2B0lFcW0m+egaHC2V3lpO8nWxyYiQ=
+github.com/lib/pq v1.10.5/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=


### PR DESCRIPTION
This resolves #5.  We pull in the database/sql library, which will be the API that we interact with the database.  The postgres driver is pq, which appears to be the most used PostgreSQL driver in golang.  We may need to find a library that does connection pooling, but this can be for later since there may be difficulties based on our database partitioning design.